### PR TITLE
Add static web portal for consultations and group sessions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,331 @@
+const consultationForm = document.getElementById('consultation-form');
+const consultationList = document.getElementById('consultation-list');
+const seatCountInput = document.getElementById('seat-count');
+const applySeatCountButton = document.getElementById('apply-seat-count');
+const addSeatButton = document.getElementById('add-seat');
+const participantNameInput = document.getElementById('participant-name');
+const startSeatSelectionButton = document.getElementById('start-seat-selection');
+const selectionMessage = document.getElementById('selection-message');
+const circle = document.getElementById('circle');
+const participantList = document.getElementById('participant-list');
+
+let consultations = [];
+let seats = [];
+let currentParticipant = null;
+let seatIdCounter = 0;
+
+function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `consultation-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function renderConsultations() {
+  consultationList.innerHTML = '';
+  if (!consultations.length) {
+    const empty = document.createElement('li');
+    empty.className = 'consultation-list__empty';
+    empty.textContent = 'Пока нет запланированных консультаций';
+    consultationList.appendChild(empty);
+    return;
+  }
+
+  consultations
+    .slice()
+    .sort((a, b) => new Date(a.datetime) - new Date(b.datetime))
+    .forEach((item) => {
+      const li = document.createElement('li');
+      li.className = 'consultation-item';
+
+      const header = document.createElement('div');
+      header.className = 'consultation-item__header';
+
+      const client = document.createElement('span');
+      client.textContent = item.client;
+      const date = document.createElement('span');
+      date.textContent = formatDateTime(item.datetime);
+      header.appendChild(client);
+      header.appendChild(date);
+
+      const meta = document.createElement('div');
+      meta.className = 'consultation-item__meta';
+      const durationText = item.duration ? `${item.duration} мин` : 'длительность не указана';
+      meta.appendChild(document.createTextNode(`${durationText} · `));
+      if (item.link) {
+        const linkElement = document.createElement('a');
+        linkElement.href = item.link;
+        linkElement.target = '_blank';
+        linkElement.rel = 'noopener';
+        linkElement.textContent = 'Перейти на встречу';
+        meta.appendChild(linkElement);
+      } else {
+        meta.appendChild(document.createTextNode('Ссылка появится позже'));
+      }
+
+      const notes = document.createElement('p');
+      notes.textContent = item.notes || 'Без дополнительных заметок';
+
+      li.appendChild(header);
+      li.appendChild(meta);
+      li.appendChild(notes);
+      consultationList.appendChild(li);
+    });
+}
+
+if (consultationForm) {
+  consultationForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const data = new FormData(consultationForm);
+
+    const entry = {
+      id: generateId(),
+      client: String(data.get('client') || '').trim(),
+      datetime: data.get('datetime'),
+      duration: Number(data.get('duration')) || null,
+    };
+
+    const link = data.get('link');
+    entry.link = link ? String(link).trim() : '';
+
+    const notes = data.get('notes');
+    entry.notes = notes ? String(notes).trim() : '';
+
+    if (!entry.client || !entry.datetime) {
+      return;
+    }
+
+    consultations.push(entry);
+    renderConsultations();
+    consultationForm.reset();
+  });
+}
+
+function initializeSeats(count) {
+  seats = Array.from({ length: count }, () => ({ id: seatIdCounter++, occupant: null }));
+  renderSeats();
+  renderParticipantList();
+}
+
+function resizeSeats(count) {
+  const activeParticipants = seats.filter((seat) => seat.occupant).map((seat) => seat.occupant);
+  if (count < activeParticipants.length) {
+    showSelectionMessage(
+      `Невозможно уменьшить круг: уже занято мест — ${activeParticipants.length}.`,
+      'error',
+    );
+    seatCountInput.value = seats.length;
+    return;
+  }
+
+  const newSeats = [];
+  for (let i = 0; i < count; i += 1) {
+    if (seats[i]) {
+      newSeats.push(seats[i]);
+    } else {
+      newSeats.push({ id: seatIdCounter++, occupant: null });
+    }
+  }
+
+  seats = newSeats;
+  renderSeats();
+  renderParticipantList();
+}
+
+function addSeat() {
+  seats.push({ id: seatIdCounter++, occupant: null });
+  seatCountInput.value = seats.length;
+  showSelectionMessage('Добавлено одно свободное место в круге.', 'success');
+  renderSeats();
+  renderParticipantList();
+}
+
+function showSelectionMessage(text, tone = 'neutral') {
+  selectionMessage.textContent = text;
+  selectionMessage.classList.remove('selection-message--success', 'selection-message--error');
+  if (tone === 'success') {
+    selectionMessage.classList.add('selection-message--success');
+  }
+  if (tone === 'error') {
+    selectionMessage.classList.add('selection-message--error');
+  }
+}
+
+function renderSeats() {
+  circle.innerHTML = '';
+  const bounds = circle.getBoundingClientRect();
+  const size = bounds.width || circle.offsetWidth;
+  if (!size) {
+    window.requestAnimationFrame(renderSeats);
+    return;
+  }
+  const radius = size / 2 - 45;
+  const centerX = size / 2;
+  const centerY = size / 2;
+
+  seats.forEach((seat, index) => {
+    const angle = (2 * Math.PI * index) / seats.length - Math.PI / 2;
+    const x = centerX + radius * Math.cos(angle) - 36;
+    const y = centerY + radius * Math.sin(angle) - 36;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'seat';
+    button.style.left = `${x}px`;
+    button.style.top = `${y}px`;
+    button.dataset.id = seat.id;
+
+    const seatIndex = document.createElement('span');
+    seatIndex.className = 'seat-index';
+    seatIndex.textContent = index + 1;
+    button.appendChild(seatIndex);
+
+    if (seat.occupant) {
+      button.classList.add('seat--occupied');
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'seat-name';
+      nameSpan.textContent = seat.occupant;
+      button.appendChild(nameSpan);
+    }
+
+    const isCurrentParticipant = seat.occupant === currentParticipant;
+    if (isCurrentParticipant) {
+      button.classList.add('seat--current');
+    }
+
+    const isSeatTakenByAnother = Boolean(seat.occupant && seat.occupant !== currentParticipant);
+    if (isSeatTakenByAnother || !currentParticipant) {
+      if (isSeatTakenByAnother) {
+        button.classList.add('seat--disabled');
+      }
+      button.disabled = isSeatTakenByAnother || !currentParticipant;
+    }
+
+    const ariaLabelParts = [`Место номер ${index + 1}`];
+    if (seat.occupant) {
+      ariaLabelParts.push(`занято участником ${seat.occupant}`);
+    } else {
+      ariaLabelParts.push('свободно');
+    }
+    button.setAttribute('aria-label', ariaLabelParts.join(', '));
+
+    button.addEventListener('click', () => handleSeatSelection(seat.id));
+    circle.appendChild(button);
+  });
+}
+
+function renderParticipantList() {
+  participantList.innerHTML = '';
+  const assignedSeats = seats.filter((seat) => seat.occupant);
+  if (!assignedSeats.length) {
+    const empty = document.createElement('li');
+    empty.className = 'consultation-list__empty';
+    empty.textContent = 'Пока никто не занял место';
+    participantList.appendChild(empty);
+    return;
+  }
+
+  assignedSeats.forEach((seat) => {
+    const seatNumber = seats.indexOf(seat) + 1;
+    const item = document.createElement('li');
+    item.className = 'participant-list__item';
+
+    const name = document.createElement('span');
+    name.textContent = seat.occupant;
+    const place = document.createElement('span');
+    place.textContent = `Место №${seatNumber}`;
+
+    item.appendChild(name);
+    item.appendChild(place);
+    participantList.appendChild(item);
+  });
+}
+
+function handleSeatSelection(seatId) {
+  if (!currentParticipant) {
+    showSelectionMessage('Введите имя участника, чтобы выбрать место.', 'error');
+    return;
+  }
+
+  const seat = seats.find((s) => s.id === seatId);
+  if (!seat || (seat.occupant && seat.occupant !== currentParticipant)) {
+    showSelectionMessage('Это место уже занято. Выберите другое.', 'error');
+    return;
+  }
+
+  seats.forEach((item) => {
+    if (item.occupant === currentParticipant) {
+      item.occupant = null;
+    }
+  });
+
+  seat.occupant = currentParticipant;
+  showSelectionMessage(`${currentParticipant} занял(а) место №${seats.indexOf(seat) + 1}.`, 'success');
+  participantNameInput.value = '';
+  currentParticipant = null;
+  renderSeats();
+  renderParticipantList();
+}
+
+startSeatSelectionButton.addEventListener('click', () => {
+  const name = participantNameInput.value.trim();
+  if (!name) {
+    showSelectionMessage('Пожалуйста, введите имя участника.', 'error');
+    return;
+  }
+
+  const alreadyAssigned = seats.find((seat) => seat.occupant === name);
+  if (alreadyAssigned) {
+    currentParticipant = name;
+    showSelectionMessage(
+      `${name}, вы уже в круге. Можете выбрать другое свободное место при необходимости.`,
+      'success',
+    );
+  } else {
+    currentParticipant = name;
+    showSelectionMessage(`${name}, выберите свободное место.`, 'success');
+  }
+
+  renderSeats();
+});
+
+applySeatCountButton.addEventListener('click', () => {
+  const value = Number.parseInt(seatCountInput.value, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    showSelectionMessage('Количество мест должно быть положительным числом.', 'error');
+    seatCountInput.value = seats.length;
+    return;
+  }
+  resizeSeats(value);
+});
+
+addSeatButton.addEventListener('click', () => {
+  addSeat();
+});
+
+window.addEventListener('resize', () => {
+  renderSeats();
+});
+
+if (participantNameInput) {
+  participantNameInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      startSeatSelectionButton.click();
+    }
+  });
+}
+
+initializeSeats(Number.parseInt(seatCountInput.value, 10) || 8);
+renderConsultations();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Онлайн консультации и групповые встречи</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <h1>Платформа для консультаций и групповой работы</h1>
+        <p>
+          Проводите индивидуальные онлайн встречи и создавайте безопасное пространство
+          для групповой работы в символическом круге.
+        </p>
+        <a class="hero__cta" href="#consultations">Начать консультацию</a>
+      </div>
+    </header>
+
+    <main>
+      <section id="consultations" class="panel">
+        <div class="panel__header">
+          <h2>Онлайн консультации</h2>
+          <p>
+            Создавайте ссылки на встречи, фиксируйте договорённости и переходите к видео прямо из интерфейса.
+          </p>
+        </div>
+
+        <div class="consultation-layout">
+          <section class="video-area" aria-label="Зона видеосвязи">
+            <div class="video-placeholder">
+              <span>Здесь может находиться ваш видеопоток или подключение к сервису видеоконференций.</span>
+            </div>
+            <div class="quick-actions">
+              <button type="button" class="button button--primary">Начать встречу</button>
+              <button type="button" class="button">Отправить приглашение</button>
+            </div>
+          </section>
+
+          <aside class="consultation-controls" aria-label="Управление консультациями">
+            <form id="consultation-form" class="form-card">
+              <h3>Запланировать консультацию</h3>
+              <label class="form-field">
+                <span>Имя клиента</span>
+                <input type="text" name="client" required placeholder="Например, Анна Иванова" />
+              </label>
+
+              <label class="form-field">
+                <span>Дата и время</span>
+                <input type="datetime-local" name="datetime" required />
+              </label>
+
+              <label class="form-field">
+                <span>Длительность (мин)</span>
+                <input type="number" name="duration" min="15" step="15" value="60" />
+              </label>
+
+              <label class="form-field">
+                <span>Ссылка на встречу</span>
+                <input type="url" name="link" placeholder="https://..." />
+              </label>
+
+              <label class="form-field">
+                <span>Заметки</span>
+                <textarea name="notes" rows="3" placeholder="Краткое описание запроса"></textarea>
+              </label>
+
+              <button type="submit" class="button button--primary button--full">Добавить в расписание</button>
+            </form>
+
+            <div class="form-card">
+              <h3>Ближайшие консультации</h3>
+              <ul id="consultation-list" class="consultation-list" aria-live="polite">
+                <li class="consultation-list__empty">Пока нет запланированных консультаций</li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section id="group" class="panel panel--accent">
+        <div class="panel__header">
+          <h2>Групповая работа в круге</h2>
+          <p>
+            Управляйте количеством мест, приглашайте участников и наблюдайте, как каждый занимает своё место в круге.
+          </p>
+        </div>
+
+        <div class="group-controls">
+          <div class="group-controls__block">
+            <label class="form-field form-field--inline">
+              <span>Количество мест</span>
+              <input id="seat-count" type="number" min="1" value="8" />
+            </label>
+            <button id="apply-seat-count" type="button" class="button">Обновить круг</button>
+          </div>
+          <button id="add-seat" type="button" class="button button--ghost">Добавить место</button>
+        </div>
+
+        <div class="participant-panel">
+          <div class="participant-panel__inputs">
+            <label class="form-field">
+              <span>Имя участника</span>
+              <input id="participant-name" type="text" placeholder="Введите имя" />
+            </label>
+            <button id="start-seat-selection" type="button" class="button button--primary">Выбрать место</button>
+          </div>
+          <p id="selection-message" class="selection-message" role="status" aria-live="polite"></p>
+        </div>
+
+        <div class="circle-wrapper">
+          <div class="circle" id="circle" aria-label="Схема круга участников"></div>
+        </div>
+
+        <aside class="group-info">
+          <h3>Участники группы</h3>
+          <ul id="participant-list" class="participant-list" aria-live="polite"></ul>
+        </aside>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>© 2024 Онлайн-платформа для консультаций. Все права защищены.</p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,446 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7fb;
+  --fg: #212121;
+  --accent: #4456ff;
+  --accent-soft: rgba(68, 86, 255, 0.1);
+  --panel: #ffffff;
+  --border: #d8dbe9;
+  --muted: #5f6275;
+  --success: #147d3f;
+  --danger: #d13d3d;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: inherit;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+a {
+  color: inherit;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(68, 86, 255, 0.9), rgba(108, 70, 255, 0.85)),
+    url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80') center / cover;
+  color: #fff;
+  padding: 6rem 1.5rem;
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero__cta {
+  display: inline-block;
+  margin-top: 1.5rem;
+  padding: 0.9rem 2.4rem;
+  background: #fff;
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+main {
+  padding: 2.5rem 1.5rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 24px;
+  padding: 2.5rem;
+  margin-bottom: 2.5rem;
+  box-shadow: 0 30px 60px -40px rgba(33, 33, 52, 0.5);
+}
+
+.panel--accent {
+  background: #f1f4ff;
+  border: 1px solid rgba(68, 86, 255, 0.1);
+}
+
+.panel__header {
+  max-width: 760px;
+  margin-bottom: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--fg);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.button:hover {
+  background: rgba(68, 86, 255, 0.08);
+  border-color: rgba(68, 86, 255, 0.2);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.button--primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+}
+
+.button--primary:hover {
+  background: #2f3ecc;
+}
+
+.button--ghost {
+  background: transparent;
+}
+
+.button--full {
+  width: 100%;
+}
+
+.consultation-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+  gap: 2rem;
+}
+
+.video-area {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.video-placeholder {
+  flex: 1;
+  min-height: 320px;
+  border-radius: 24px;
+  border: 2px dashed rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  padding: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 1.05rem;
+}
+
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.consultation-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-card {
+  background: #fff;
+  border-radius: 20px;
+  border: 1px solid rgba(68, 86, 255, 0.1);
+  padding: 1.75rem;
+  box-shadow: 0 16px 40px -36px rgba(12, 27, 90, 0.6);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+
+.form-field--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0;
+}
+
+.form-field span {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+input,
+textarea {
+  font: inherit;
+  padding: 0.65rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #fafbff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  border-color: rgba(68, 86, 255, 0.6);
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(68, 86, 255, 0.18);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.consultation-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.consultation-item {
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(68, 86, 255, 0.12);
+  background: var(--accent-soft);
+}
+
+.consultation-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  font-weight: 600;
+}
+
+.consultation-item__meta {
+  margin-top: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.consultation-list__empty {
+  text-align: center;
+  padding: 1.25rem;
+  color: var(--muted);
+  background: rgba(95, 98, 117, 0.08);
+  border-radius: 16px;
+  border: 1px dashed rgba(95, 98, 117, 0.3);
+}
+
+.group-controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.group-controls__block {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.participant-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.participant-panel__inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.participant-panel__inputs .form-field {
+  flex: 1;
+  min-width: 220px;
+  margin: 0;
+}
+
+.selection-message {
+  min-height: 1.2rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.selection-message--success {
+  color: var(--success);
+}
+
+.selection-message--error {
+  color: var(--danger);
+}
+
+.circle-wrapper {
+  position: relative;
+  width: min(100%, 540px);
+  margin: 0 auto;
+}
+
+.circle {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(68, 86, 255, 0.12), transparent 60%);
+  border: 1px dashed rgba(68, 86, 255, 0.35);
+}
+
+.seat {
+  position: absolute;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: #fff;
+  box-shadow: 0 16px 36px -32px rgba(12, 27, 90, 0.8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.seat:hover:not(.seat--occupied):not(.seat--disabled) {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 18px 36px -24px rgba(68, 86, 255, 0.6);
+  border-color: rgba(68, 86, 255, 0.4);
+}
+
+.seat--occupied {
+  background: var(--accent);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.seat--current {
+  border-color: rgba(20, 125, 63, 0.9);
+  box-shadow: 0 18px 32px -20px rgba(20, 125, 63, 0.55);
+}
+
+.seat--disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.seat-index {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.seat-name {
+  font-size: 0.75rem;
+  margin-top: 0.2rem;
+}
+
+.group-info {
+  margin-top: 3rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(68, 86, 255, 0.08);
+  border: 1px solid rgba(68, 86, 255, 0.2);
+}
+
+.participant-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.participant-list__item {
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid rgba(68, 86, 255, 0.15);
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+  .consultation-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .video-placeholder {
+    min-height: 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .panel {
+    padding: 2rem;
+  }
+
+  .group-controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .group-controls__block {
+    width: 100%;
+  }
+
+  .participant-panel__inputs {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .participant-panel__inputs .button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a landing page with consultation management and group circle sections
- style the experience with responsive layouts, action buttons, and seating visuals
- implement client-side logic for scheduling, seat assignment, and dynamic participant updates

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caaf73aff48321b8bbdffde8bcbff5